### PR TITLE
Schedule tasks using non-jumping clock

### DIFF
--- a/examples/SimpleApp/src/main.cpp
+++ b/examples/SimpleApp/src/main.cpp
@@ -26,8 +26,8 @@ public:
     }
 
 protected:
-    const Schedule loop(time_point<steady_clock> scheduledTime) override {
-        auto now = steady_clock::now();
+    const Schedule loop(time_point<boot_clock> scheduledTime) override {
+        auto now = boot_clock::now();
         Serial.printf("Simple app has been running for %ld seconds (drift %ld ms)\n",
             (long) duration_cast<seconds>(now.time_since_epoch()).count(),
             (long) duration_cast<milliseconds>(now - scheduledTime).count());

--- a/examples/SimpleApp/src/main.cpp
+++ b/examples/SimpleApp/src/main.cpp
@@ -28,9 +28,10 @@ public:
 protected:
     const Schedule loop(time_point<boot_clock> scheduledTime) override {
         auto now = boot_clock::now();
-        Serial.printf("Simple app has been running for %ld seconds (drift %ld ms)\n",
+        microseconds drift = now - scheduledTime;
+        Serial.printf("Simple app has been running for %ld seconds (drift %ld us)\n",
             (long) duration_cast<seconds>(now.time_since_epoch()).count(),
-            (long) duration_cast<milliseconds>(now - scheduledTime).count());
+            (long) drift.count());
         return repeatAsapAfter(seconds { 10 });
     }
 };

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -41,7 +41,7 @@ protected:
         const String& name,
         const String& version,
         WiFiProvider& wifiProvider,
-        milliseconds maxSleepTime = minutes { 1 })
+        microseconds maxSleepTime = minutes { 1 })
         : name(name)
         , version(version)
         , wifiProvider(wifiProvider)

--- a/src/BootClock.hpp
+++ b/src/BootClock.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <Arduino.h>
+#include <chrono>
+
+using namespace std;
+
+namespace farmhub { namespace client {
+
+/**
+  *  @brief Monotonic clock based on ESP's esp_timer_get_time()
+  *
+  *  Time returned has the property of only increasing at a uniform rate.
+  */
+struct boot_clock {
+    typedef chrono::microseconds duration;
+    typedef duration::rep rep;
+    typedef duration::period period;
+    typedef chrono::time_point<boot_clock, duration> time_point;
+
+    static constexpr bool is_steady = true;
+
+    static time_point now() noexcept {
+        return time_point(duration(micros()));
+    }
+};
+
+}}    // namespace farmhub::client

--- a/src/BootClock.hpp
+++ b/src/BootClock.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Arduino.h>
 #include <chrono>
+#include <esp_timer.h>
 
 using namespace std;
 
@@ -21,7 +21,7 @@ struct boot_clock {
     static constexpr bool is_steady = true;
 
     static time_point now() noexcept {
-        return time_point(duration(micros()));
+        return time_point(duration(esp_timer_get_time()));
     }
 };
 

--- a/src/MqttHandler.hpp
+++ b/src/MqttHandler.hpp
@@ -112,7 +112,7 @@ public:
     }
 
 protected:
-    const Schedule loop(time_point<steady_clock> scheduledTime) override {
+    const Schedule loop(time_point<boot_clock> scheduledTime) override {
         if (WiFi.status() != WL_CONNECTED) {
             Serial.println("Waiting to connect to MQTT until WIFI is available");
             return repeatAsapAfter(seconds { 1 });

--- a/src/OtaHandler.hpp
+++ b/src/OtaHandler.hpp
@@ -49,7 +49,7 @@ public:
         ArduinoOTA.begin();
     }
 
-    const Schedule loop(time_point<steady_clock> scheduledTime) override {
+    const Schedule loop(time_point<boot_clock> scheduledTime) override {
         ArduinoOTA.handle();
         return updating
             ? repeatImmediately()

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -105,7 +105,7 @@ public:
         Serial.printf("Now @%ld\n", (long) duration_cast<milliseconds>(now.time_since_epoch()).count());
 #endif
 
-        auto nextRound = std::max(now, previousRound + maxSleepTime);
+        auto nextRound = previousRound + maxSleepTime;
         for (auto& entry : tasks) {
 #ifdef LOG_TASKS
             Serial.printf("Considering '%s' with next @%ld",
@@ -120,7 +120,7 @@ public:
                     ? now
                     : entry.next;
                 auto schedule = entry.task.loop(scheduledTime);
-                auto nextScheduledTime = std::max(now, scheduledTime + schedule.delay);
+                auto nextScheduledTime = scheduledTime + schedule.delay;
                 nextRound = std::min(nextRound, nextScheduledTime);
                 switch (schedule.type) {
                     case Task::ScheduleType::AFTER:


### PR DESCRIPTION
Base a clock on `esp_timer_get_time()` that does not change when NTP updates the system clock. It also uses an `int64_t`, so it doesn't roll over.

Fixes #23.