### PR TITLE
Rework task scheduling methods

### DIFF
--- a/examples/SimpleApp/src/main.cpp
+++ b/examples/SimpleApp/src/main.cpp
@@ -39,7 +39,7 @@ protected:
         Serial.printf("Simple app has been running for %ld seconds (drift %ld us)\n",
             (long) duration_cast<seconds>(now.time_since_epoch()).count(),
             (long) drift.count());
-        return repeatAsapAfter(seconds { 10 });
+        return sleepFor(seconds { 10 });
     }
 };
 

--- a/src/MqttHandler.hpp
+++ b/src/MqttHandler.hpp
@@ -115,13 +115,13 @@ protected:
     const Schedule loop(time_point<boot_clock> scheduledTime) override {
         if (WiFi.status() != WL_CONNECTED) {
             Serial.println("Waiting to connect to MQTT until WIFI is available");
-            return repeatAsapAfter(seconds { 1 });
+            return sleepFor(seconds { 1 });
         }
 
         if (!mqttClient.connected()) {
             if (!tryConnect()) {
                 // Try connecting again in 10 seconds
-                return repeatAsapAfter(seconds { 10 });
+                return sleepFor(seconds { 10 });
             }
         }
 
@@ -139,7 +139,7 @@ protected:
 
         mqttClient.loop();
         // TODO We could repeat sooner if we couldn't publish everything
-        return repeatAsapAfter(milliseconds { MQTT_POLL_FREQUENCY });
+        return sleepFor(milliseconds { MQTT_POLL_FREQUENCY });
     }
 
 private:

--- a/src/OtaHandler.hpp
+++ b/src/OtaHandler.hpp
@@ -52,8 +52,8 @@ public:
     const Schedule loop(time_point<boot_clock> scheduledTime) override {
         ArduinoOTA.handle();
         return updating
-            ? repeatImmediately()
-            : repeatAsapAfter(seconds { 1 });
+            ? yieldImmediately()
+            : sleepFor(seconds { 1 });
     }
 
 private:

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -91,7 +91,7 @@ protected:
      * We will execute the task again when another task gets scheduled.
      */
     static const Schedule sleepIndefinitely() {
-        return Schedule(ScheduleType::BEFORE, microseconds::max());
+        return Schedule(ScheduleType::BEFORE, hours { 24 * 365 * 100 });
     }
 };
 

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -61,8 +61,8 @@ protected:
     /**
      * @brief Repeat the task immediately after running other tasks.
      */
-    static const Schedule repeatImmediately() {
-        return Schedule(ScheduleType::AFTER, microseconds(0));
+    static const Schedule yieldImmediately() {
+        return Schedule(ScheduleType::AFTER, microseconds::zero());
     }
 
     /**
@@ -71,7 +71,7 @@ protected:
      * It is guaranteed that the task will not repeat before the given delay.
      * The delay might be longer than specified if other tasks take longer to execute.
      */
-    static const Schedule repeatAsapAfter(microseconds delay) {
+    static const Schedule sleepFor(microseconds delay) {
         return Schedule(ScheduleType::AFTER, delay);
     }
 
@@ -81,7 +81,7 @@ protected:
      * We will execute the task again either after the given delay,
      * or when another task gets scheduled (whichever happens earlier).
      */
-    static const Schedule repeatAlapBefore(microseconds delay) {
+    static const Schedule sleepAtMost(microseconds delay) {
         return Schedule(ScheduleType::BEFORE, delay);
     }
 
@@ -90,7 +90,7 @@ protected:
      *
      * We will execute the task again when another task gets scheduled.
      */
-    static const Schedule repeatAlap() {
+    static const Schedule sleepIndefinitely() {
         return Schedule(ScheduleType::BEFORE, microseconds::max());
     }
 };
@@ -107,7 +107,7 @@ public:
 protected:
     const Schedule loop(time_point<boot_clock> scheduledTime) override {
         callback();
-        return repeatAsapAfter(delay);
+        return sleepFor(delay);
     }
 
 private:

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -58,16 +58,40 @@ protected:
     virtual const Schedule loop(time_point<boot_clock> scheduledTime) = 0;
     friend class TaskContainer;
 
+    /**
+     * @brief Repeat the task immediately after running other tasks.
+     */
     static const Schedule repeatImmediately() {
         return Schedule(ScheduleType::AFTER, microseconds(0));
     }
 
+    /**
+     * @brief Repeat the task as soon as possible after a given delay.
+     *
+     * It is guaranteed that the task will not repeat before the given delay.
+     * The delay might be longer than specified if other tasks take longer to execute.
+     */
     static const Schedule repeatAsapAfter(microseconds delay) {
         return Schedule(ScheduleType::AFTER, delay);
     }
 
+    /**
+     * @brief Repeat the task as late as possible before the given delay.
+     *
+     * We will execute the task again either after the given delay,
+     * or when another task gets scheduled (whichever happens earlier).
+     */
     static const Schedule repeatAlapBefore(microseconds delay) {
         return Schedule(ScheduleType::BEFORE, delay);
+    }
+
+    /**
+     * @brief Repeat the task as late as possible.
+     *
+     * We will execute the task again when another task gets scheduled.
+     */
+    static const Schedule repeatAlap() {
+        return Schedule(ScheduleType::BEFORE, microseconds::max());
     }
 };
 


### PR DESCRIPTION
Adds a `Task.sleepIndefinitely()` method to 'sleep' until another task wakes up the scheduler.

Other methods are renamed, too.