### PR TITLE
Fix passing property to lambda

### DIFF
--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -226,7 +226,7 @@ public:
     template <typename Duration = milliseconds>
     IntervalTask(TaskContainer& tasks, const String& name, const Property<Duration>& delay, std::function<void()> callback)
         : BaseTask(tasks, name)
-        , delay([delay]() {
+        , delay([&delay]() {
             return duration_cast<microseconds>(delay.get());
         })
         , callback(callback) {


### PR DESCRIPTION
Apparently even if the parameter is passed as a const&, lambda parameters are resolved to the instance.