### PR TITLE
Wake up after application has begun

### DIFF
--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -152,9 +152,9 @@ private:
 
         mqtt.begin();
 
-        sleep.begin();
-
         beginApp();
+
+        sleep.handleWake();
     }
 
     void beginFileSystem() {

--- a/src/Sleep.hpp
+++ b/src/Sleep.hpp
@@ -42,7 +42,7 @@ class SleepHandler {
 public:
     SleepHandler() = default;
 
-    void begin() {
+    void handleWake() {
         WakeEvent event { esp_sleep_get_wakeup_cause() };
         for (auto& listener : listeners) {
             listener.get().onWake(event);


### PR DESCRIPTION
Do not emit wakeup events before the application went through the `begin()` phase.