### PR TITLE
Pin Espressif32 platform to 4.2.0

### DIFF
--- a/examples/SimpleApp/platformio.ini
+++ b/examples/SimpleApp/platformio.ini
@@ -3,7 +3,7 @@ default_envs = esp32
 
 [env:esp32]
 framework = arduino
-platform = espressif32
+platform = espressif32@^4.2.0
 board = esp32dev
 ; From https://github.com/espressif/arduino-esp32/blob/674cf812e7feb42aafd644649c1889d59af447f2/tools/partitions/min_spiffs.csv
 board_build.partitions = partitions.csv

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -132,20 +132,20 @@ private:
         WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
             Serial.println("WiFi: connected to " + WiFi.SSID());
         },
-            SYSTEM_EVENT_STA_CONNECTED);
+            ARDUINO_EVENT_WIFI_STA_CONNECTED);
         WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
             Serial.printf("WiFi: got IP address: %s, hostname: '%s'\n",
                 WiFi.localIP().toString().c_str(), WiFi.getHostname());
         },
-            SYSTEM_EVENT_STA_GOT_IP);
+            ARDUINO_EVENT_WIFI_STA_GOT_IP);
         WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
             Serial.println("WiFi: lost IP address");
         },
-            SYSTEM_EVENT_STA_LOST_IP);
+            ARDUINO_EVENT_WIFI_STA_LOST_IP);
         WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
             Serial.println("WiFi: disconnected");
         },
-            SYSTEM_EVENT_STA_DISCONNECTED);
+            ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
         wifiProvider.begin(hostname);
 
         otaHandler.begin(hostname);

--- a/src/MdnsHandler.hpp
+++ b/src/MdnsHandler.hpp
@@ -17,7 +17,7 @@ public:
                 MDNS.setInstanceName(instanceName);
                 MDNS.addServiceTxt("arduino", "tcp", "version", version);
             },
-            SYSTEM_EVENT_STA_GOT_IP);
+            ARDUINO_EVENT_WIFI_STA_GOT_IP);
     }
 
     // Lookup host name via MDNS explicitly


### PR DESCRIPTION
It uses Arduino ESP32 2.0.2 with support for ESP32-S3 and C3.

Fixes #65.