### PR TITLE
Retain application 'init' message

### DIFF
--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -195,7 +195,7 @@ private:
                 json["app"] = app;
                 json["version"] = version;
                 json["wakeup"] = event.source;
-            });
+            }, MqttHandler::RetainType::Retain);
         }
 
     private:


### PR DESCRIPTION
The `init` message was not retained for some versions for some reason.