### PR TITLE
Support both ESP Arduino 1.x and 2.x

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "functional": "cpp"
+    }
+}

--- a/examples/SimpleApp/platformio.ini
+++ b/examples/SimpleApp/platformio.ini
@@ -3,7 +3,7 @@ default_envs = esp32
 
 [env:esp32]
 framework = arduino
-platform = espressif32@^4.2.0
+platform = espressif32@^3.5.0
 board = esp32dev
 ; From https://github.com/espressif/arduino-esp32/blob/674cf812e7feb42aafd644649c1889d59af447f2/tools/partitions/min_spiffs.csv
 board_build.partitions = partitions.csv

--- a/src/Farmhub.hpp
+++ b/src/Farmhub.hpp
@@ -2,6 +2,15 @@
 
 #include <Arduino.h>
 
+// Arduino 2 constants for Arduino 1 compatibility
+#ifndef ESP_ARDUINO_VERSION
+#define ARDUINO_EVENT_WIFI_STA_GOT_IP SYSTEM_EVENT_STA_GOT_IP
+#define ARDUINO_EVENT_WIFI_STA_LOST_IP SYSTEM_EVENT_STA_LOST_IP
+#define ARDUINO_EVENT_WIFI_STA_CONNECTED SYSTEM_EVENT_STA_CONNECTED
+#define ARDUINO_EVENT_WIFI_STA_DISCONNECTED SYSTEM_EVENT_STA_DISCONNECTED
+#define GPIO_NUM_NC -1
+#endif
+
 namespace farmhub { namespace client {
 
 void fatalError(String message) {


### PR DESCRIPTION
Arduino-ESP32 2.0.2 has some bug related to networking that prevents our code from working well. Symptoms include NTP server taking a long time to connect, and SSL connection to github.com failing upon HTTP update.

So we need Arduino 1.x support until Arduino 2.x fixes the problems.