### PR TITLE
Do not retain init messages

### DIFF
--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -213,8 +213,7 @@ private:
                     json["app"] = app;
                     json["version"] = version;
                     json["wakeup"] = event.source;
-                },
-                MqttHandler::RetainType::Retain);
+                });
         }
 
     private:


### PR DESCRIPTION
We shouldn't use MQTT to keep track of which device is initialized, as it's not a good way to do so. Instead, we should maintain the list of active devices in a separate database.

Helps with:
- https://github.com/kivancsikert/motherhen-flows/issues/6