### PR TITLE
Use MAC address for instance and topic

### DIFF
--- a/examples/SimpleApp/data/device-config.json
+++ b/examples/SimpleApp/data/device-config.json
@@ -1,6 +1,4 @@
 {
-  "type": "simple-example",
-  "model": "mk1",
-  "instance": "test",
-  "description": "Simple Example for FarmHub Client – https://github.com/kivancsikert/farmhub-client/"
+  "type": "ugly-duckling",
+  "model": "mk4"
 }

--- a/examples/SimpleApp/platformio.ini
+++ b/examples/SimpleApp/platformio.ini
@@ -2,17 +2,15 @@
 default_envs = lilygo-t8
 
 [esp32base]
-platform = espressif32@~5.0.0
+platform = espressif32@~6.0.1
 framework = arduino
-platform_packages =
-    framework-arduinoespressif32@https://github.com/espressif/arduino-esp32.git#2.0.4
 ; From https://github.com/espressif/arduino-esp32/blob/674cf812e7feb42aafd644649c1889d59af447f2/tools/partitions/min_spiffs.csv
 board_build.partitions = partitions.csv
 lib_deps =
-	bblanchon/ArduinoJson@^6.19.4
+	bblanchon/ArduinoJson@^6.20.1
 	256dpi/MQTT@^2.5.0
     rlogiacco/CircularBuffer@^1.3.3
-    https://github.com/tzapu/WiFiManager.git#v2.0.11-beta
+    https://github.com/tzapu/WiFiManager.git#v2.0.15-rc.1
 lib_extra_dirs =
     ../..
 build_type = debug

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "farmhub-client",
-  "version": "0.12.8",
+  "version": "0.13.0",
   "description": "FarmHub IoT client platform",
   "keywords": "arduino json configuration mqtt",
   "repository": {


### PR DESCRIPTION
By default derive the instance, hostname and MQTT topic from the MAC address of the device.

Also remove the `description` property of the device configuration.