### PR TITLE
Report MAC address on init

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
-        "functional": "cpp"
+        "functional": "cpp",
+        "chrono": "cpp"
     },
     "sonarlint.pathToCompileCommands": "${workspaceFolder}/examples/SimpleApp/compile_commands.json"
 }


### PR DESCRIPTION
This allows checking the MAC even if an explicit instance is configured for the device.