### PR TITLE
Add resetWifi command

### DIFF
--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -13,9 +13,10 @@
 #include <Sleep.hpp>
 #include <Telemetry.hpp>
 #include <commands/EchoCommand.hpp>
-#include <commands/PingCommand.hpp>
 #include <commands/FileCommands.hpp>
 #include <commands/HttpUpdateCommand.hpp>
+#include <commands/PingCommand.hpp>
+#include <commands/ResetWifiCommand.hpp>
 #include <commands/RestartCommand.hpp>
 #include <wifi/WiFiProvider.hpp>
 
@@ -85,11 +86,13 @@ protected:
         , deviceConfig(deviceConfig)
         , appConfig(appConfig)
         , wifiProvider(wifiProvider)
+        , resetWifiCommand(wifiProvider)
         , httpUpdateCommand(version)
         , tasks(maxSleepTime) {
 
         mqtt.registerCommand("echo", echoCommand);
         mqtt.registerCommand("ping", pingCommand);
+        mqtt.registerCommand("resetWifi", resetWifiCommand);
         mqtt.registerCommand("restart", restartCommand);
         mqtt.registerCommand("files/list", fileListCommand);
         mqtt.registerCommand("files/read", fileReadCommand);
@@ -258,6 +261,7 @@ private:
     commands::FileWriteCommand fileWriteCommand;
     commands::FileRemoveCommand fileRemoveCommand;
     commands::HttpUpdateCommand httpUpdateCommand;
+    commands::ResetWifiCommand resetWifiCommand;
     commands::RestartCommand restartCommand;
     commands::PingCommand pingCommand { telemetryPublisher };
 };

--- a/src/commands/ResetWifiCommand.hpp
+++ b/src/commands/ResetWifiCommand.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <MqttHandler.hpp>
+#include <wifi/WiFiProvider.hpp>
+
+namespace farmhub { namespace client { namespace commands {
+
+class ResetWifiCommand : public MqttHandler::Command {
+public:
+    ResetWifiCommand(WiFiProvider& wifiProvider)
+        : wifiProvider(wifiProvider) {
+    }
+
+    void handle(const JsonObject& request, JsonObject& response) override {
+        wifiProvider.resetSettings();
+        response["reset"] = true;
+    }
+private:
+    WiFiProvider& wifiProvider;
+};
+
+}}}    // namespace farmhub::client::commands

--- a/src/wifi/WiFiManagerProvider.hpp
+++ b/src/wifi/WiFiManagerProvider.hpp
@@ -41,6 +41,10 @@ public:
 
     WiFiManager wm;
 
+    void resetSettings() {
+        wm.resetSettings();
+    }
+
 protected:
     const seconds connectionTimeout;
     const seconds configurationTimeout;

--- a/src/wifi/WiFiProvider.hpp
+++ b/src/wifi/WiFiProvider.hpp
@@ -7,6 +7,11 @@ namespace farmhub { namespace client {
 class WiFiProvider {
 public:
     virtual void begin(const String& hostname) = 0;
+
+    /**
+     * Reset stored configuration.
+     */
+    virtual void resetSettings() = 0;
 };
 
 }}    // namespace farmhub::client


### PR DESCRIPTION
Sending `resetWifi` to `commands` resets the stored credentials, so next time the device boots it will require to be configured.